### PR TITLE
added support to upper

### DIFF
--- a/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/RewriteUpper.java
+++ b/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/RewriteUpper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.teradata;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static java.lang.String.format;
+
+public class RewriteUpper
+        implements ConnectorExpressionRule<Call, ParameterizedExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    public static final FunctionName UPPER_FUNCTION_NAME = new FunctionName("upper");
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(UPPER_FUNCTION_NAME))
+            .with(argumentCount().equalTo(1))
+            .with(argument(0).matching(expression().capturedAs(VALUE)));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<ParameterizedExpression> rewrite(Call call, Captures captures, RewriteContext<ParameterizedExpression> context)
+    {
+        Optional<ParameterizedExpression> value = context.defaultRewrite(captures.get(VALUE));
+        return value.map(parameterizedExpression -> new ParameterizedExpression(
+                format("UPPER(%s)", parameterizedExpression.expression()),
+                parameterizedExpression.parameters()));
+    }
+}

--- a/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/RewriteUpperFunction.java
+++ b/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/RewriteUpperFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.teradata;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.projection.ProjectFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.VarcharType;
+
+import java.sql.JDBCType;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+
+public class RewriteUpperFunction
+        implements ProjectFunctionRule<JdbcExpression, ParameterizedExpression>
+{
+    private static final Capture<Variable> ARGUMENT = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(new FunctionName("upper")))
+            .with(type().matching(type -> type instanceof VarcharType))
+            .with(argumentCount().equalTo(1))
+            .with(argument(0).matching(variable().capturedAs(ARGUMENT).with(type().matching(type -> type instanceof VarcharType))));
+
+    @Override
+    public Pattern<? extends ConnectorExpression> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(ConnectorTableHandle handle, ConnectorExpression projectionExpression, Captures captures, RewriteContext<ParameterizedExpression> context)
+    {
+        Variable argument = captures.get(ARGUMENT);
+        JdbcTypeHandle typeHandle = ((JdbcColumnHandle) context.getAssignment(argument.getName())).getJdbcTypeHandle();
+
+        if (JDBCType.valueOf(typeHandle.jdbcType()) == JDBCType.VARCHAR
+                && typeHandle.jdbcTypeName().map(name -> name.equalsIgnoreCase("varchar")).orElse(false)) {
+            Optional<ParameterizedExpression> translatedArgument = context.rewriteExpression(argument);
+            if (translatedArgument.isEmpty()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new JdbcExpression(
+                    "UPPER(%s)".formatted(translatedArgument.get().expression()),
+                    ImmutableList.copyOf(translatedArgument.get().parameters()),
+                    typeHandle));
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/TeradataClient.java
+++ b/plugin/trino-teradata/src/main/java/io/trino/plugin/teradata/TeradataClient.java
@@ -738,6 +738,7 @@ public class TeradataClient
                 connectorExpressionRewriter,
                 com.google.common.collect.ImmutableSet.<ProjectFunctionRule<JdbcExpression, ParameterizedExpression>>builder()
                         .add(new RewriteLowerFunction())
+                        .add(new RewriteUpperFunction())
                         .build());
     }
 
@@ -750,6 +751,7 @@ public class TeradataClient
                 .add(new RewriteLikeEscapeWithCaseSensitivity())
                 .add(new RewriteSubstring())
                 .add(new RewriteLower())
+                .add(new RewriteUpper())
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))
                 .withTypeClass("numeric_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint", "decimal", "real", "double"))
                 .withTypeClass("string_type", ImmutableSet.of("varchar"))

--- a/plugin/trino-teradata/src/test/java/io/trino/plugin/integration/TeradataConnectorTest.java
+++ b/plugin/trino-teradata/src/test/java/io/trino/plugin/integration/TeradataConnectorTest.java
@@ -872,4 +872,94 @@ public final class TeradataConnectorTest
             assertQuery(format("SELECT array_data FROM %s WHERE id = 3", table.getName()), "VALUES 'ARRAY[null, null, null]'");
         }
     }
+
+    @Test
+    public void testLowerSelectProjection()
+    {
+        assertQuery(
+                "SELECT nationkey, LOWER(name) AS lower_name FROM teradata.trino.nation ORDER BY nationkey LIMIT 5",
+                "VALUES " +
+                        "(0, 'algeria'), " +
+                        "(1, 'argentina'), " +
+                        "(2, 'brazil'), " +
+                        "(3, 'canada'), " +
+                        "(4, 'egypt')");
+    }
+
+    @Test
+    public void testUpperSelectProjection()
+    {
+        assertQuery(
+                "SELECT nationkey, UPPER(name) AS upper_name FROM teradata.trino.nation ORDER BY nationkey LIMIT 5",
+                "VALUES " +
+                        "(0, 'ALGERIA'), " +
+                        "(1, 'ARGENTINA'), " +
+                        "(2, 'BRAZIL'), " +
+                        "(3, 'CANADA'), " +
+                        "(4, 'EGYPT')");
+    }
+
+    @Test
+    public void testSubstringSelectProjection()
+    {
+        assertQuery(
+                "SELECT SUBSTRING(name, 1, 2) AS name_prefix FROM teradata.trino.nation WHERE nationkey IN (0, 1, 2) ORDER BY nationkey",
+                "VALUES 'AL', 'AR', 'BR'");
+    }
+
+    @Test
+    public void testLowerInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE LOWER(name) = 'algeria'",
+                "VALUES ('ALGERIA', 0, 0)");
+    }
+
+    @Test
+    public void testUpperInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE UPPER(name) = 'BRAZIL'",
+                "VALUES ('BRAZIL', 1, 2)");
+    }
+
+    @Test
+    public void testSubstringTwoParamsInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE SUBSTRING(name, 1, 2) = 'AR'",
+                "VALUES ('ARGENTINA', 1, 1)");
+    }
+
+    @Test
+    public void testSubstringOneParamInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE SUBSTRING(name, 1) = 'CANADA'",
+                "VALUES ('CANADA', 1, 3)");
+    }
+
+    @Test
+    public void testNestedUpperSubstringInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE UPPER(SUBSTRING(name, 1, 1)) = 'F'",
+                "SELECT name, regionkey, nationkey FROM nation WHERE name LIKE 'F%'");
+    }
+
+    @Test
+    public void testNestedLowerSubstringInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE LOWER(SUBSTRING(name, 1, 3)) = 'uni'",
+                "SELECT name, regionkey, nationkey FROM nation WHERE LOWER(SUBSTRING(name, 1, 3)) = 'uni'");
+    }
+
+    @Test
+    public void testNestedSubstringUpperInWhereClause()
+    {
+        assertQuery(
+                "SELECT name, regionkey, nationkey FROM teradata.trino.nation WHERE SUBSTRING(UPPER(name), 1, 2) IN ('BR', 'FR', 'GE')",
+                "SELECT name, regionkey, nationkey FROM nation WHERE SUBSTRING(UPPER(name), 1, 2) IN ('BR', 'FR', 'GE')");
+    }
 }

--- a/plugin/trino-teradata/src/test/java/io/trino/plugin/unit/TestRewriteUpper.java
+++ b/plugin/trino-teradata/src/test/java/io/trino/plugin/unit/TestRewriteUpper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.unit;
+
+import io.trino.plugin.teradata.RewriteUpper;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRewriteUpper
+{
+    private final RewriteUpper rewriteUpper = new RewriteUpper();
+
+    @Test
+    public void testPatternMatchesUpperFunction()
+    {
+        Variable variable = new Variable("test_column", VarcharType.VARCHAR);
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of(variable));
+        boolean matches = rewriteUpper.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isTrue();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchOtherFunctions()
+    {
+        Variable variable = new Variable("test_column", VarcharType.VARCHAR);
+        Call lowerCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("lower"),
+                List.of(variable));
+        boolean matches = rewriteUpper.getPattern().match(lowerCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchWrongArgumentCount()
+    {
+        Variable variable1 = new Variable("col1", VarcharType.VARCHAR);
+        Variable variable2 = new Variable("col2", VarcharType.VARCHAR);
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of(variable1, variable2));
+        boolean matches = rewriteUpper.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchEmptyArguments()
+    {
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of());
+        boolean matches = rewriteUpper.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+}

--- a/plugin/trino-teradata/src/test/java/io/trino/plugin/unit/TestRewriteUpperFunction.java
+++ b/plugin/trino-teradata/src/test/java/io/trino/plugin/unit/TestRewriteUpperFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.unit;
+
+import io.trino.plugin.teradata.RewriteUpperFunction;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRewriteUpperFunction
+{
+    private final RewriteUpperFunction rewriteUpperFunction = new RewriteUpperFunction();
+
+    @Test
+    public void testPatternMatchesUpperFunctionWithVarcharArgument()
+    {
+        Variable variable = new Variable("test_column", VarcharType.VARCHAR);
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of(variable));
+        boolean matches = rewriteUpperFunction.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isTrue();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchNonVarcharArgument()
+    {
+        Variable variable = new Variable("test_column", IntegerType.INTEGER);
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of(variable));
+        boolean matches = rewriteUpperFunction.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchOtherFunctions()
+    {
+        Variable variable = new Variable("test_column", VarcharType.VARCHAR);
+        Call lowerCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("lower"),
+                List.of(variable));
+        boolean matches = rewriteUpperFunction.getPattern().match(lowerCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchWrongArgumentCount()
+    {
+        Variable variable1 = new Variable("col1", VarcharType.VARCHAR);
+        Variable variable2 = new Variable("col2", VarcharType.VARCHAR);
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of(variable1, variable2));
+        boolean matches = rewriteUpperFunction.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void testPatternDoesNotMatchEmptyArguments()
+    {
+        Call upperCall = new Call(
+                VarcharType.VARCHAR,
+                new FunctionName("upper"),
+                List.of());
+        boolean matches = rewriteUpperFunction.getPattern().match(upperCall).findFirst().isPresent();
+        assertThat(matches).isFalse();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR implements support for pushing down the UPPER function to the Teradata database. This enhancement improves query performance by reducing data transfer and leveraging Teradata's native string processing capabilities.

**Changes Made**

- Added RewriteUpperFunction class to handle UPPER function projection pushdown.
- Added RewriteUpper class for expression rewriting in predicates.
- Integrated both rewriters into the TeradataClient expression and projection function rewriters.
- Enhanced function pushdown optimization framework to support case conversion operations.

**Technical Details**

- Validates that the input argument is of string type before applying the pushdown.
- Uses Teradata's native UPPER function syntax for optimal performance.
- Integrates seamlessly with existing expression rewriting framework.
- Compatible with both predicate and projection contexts.
- Follows established patterns for function pushdown in the Teradata connector.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

**Testing Considerations:**

- Verify that UPPER function works correctly with various string types (VARCHAR, CHAR, CLOB)
- Ensure proper integration with existing predicate and projection pushdown functionality
- Validate case conversion accuracy across different character sets and locales
- Test combined usage with other string functions and expressions

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

**Teradata Connector Enhancements**

**New Features:**

UPPER Function Pushdown: The Teradata connector now supports pushing down UPPER function calls to the database, improving query performance for case conversion operations.

**Performance Improvements:**

Reduced network overhead for queries using UPPER function by leveraging native Teradata string processing
Enhanced execution plans for queries involving uppercase string transformations

**Technical Enhancements:**

- Added support for UPPER function in both predicate and projection contexts
- Maintains proper type validation to ensure safe function pushdown
- Seamless integration with existing expression rewriting framework
- Consistent behavior with other string function pushdown implementations
- 
( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
